### PR TITLE
Some improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var exec = require('child_process').execSync
 var path = require('path')
 var fs = require('fs')
 
-var globalModulesPath = String(exec('npm root -g')).replace(/\r?\n|\r/g, '')
+var globalModulesPath = String(exec('npm root -g')).replace(/[\r\n]+/g, '')
 
 function globalResolve (module) {
   return path.resolve(globalModulesPath, module)

--- a/index.js
+++ b/index.js
@@ -2,12 +2,12 @@ var exec = require('child_process').execSync
 var path = require('path')
 var fs = require('fs')
 
+var globalModulesPath = String(exec('npm root -g')).replace(/\r?\n|\r/g, '')
+
 module.exports = function requireLocalNodeModule (module) {
   if (typeof module !== 'string' || !module.length) {
     throw new Error('Expecting module to be non-empty string')
   }
-
-  var globalModulesPath = String(exec('npm root -g')).replace(/\r?\n|\r/g, '')
 
   return require(path.resolve(globalModulesPath, module))
 }

--- a/index.js
+++ b/index.js
@@ -4,14 +4,17 @@ var fs = require('fs')
 
 var globalModulesPath = String(exec('npm root -g')).replace(/\r?\n|\r/g, '')
 
-exports.resolve = function globalResolve (module) {
+function globalResolve (module) {
   return path.resolve(globalModulesPath, module)
 }
 
-module.exports = function requireLocalNodeModule (module) {
+function globalRequire (module) {
   if (typeof module !== 'string' || !module.length) {
     throw new Error('Expecting module to be non-empty string')
   }
 
-  return require(exports.resolve(module))
+  return require(globalResolve(module))
 }
+
+globalRequire.resolve = globalResolve
+module.exports = globalRequire

--- a/index.js
+++ b/index.js
@@ -4,10 +4,14 @@ var fs = require('fs')
 
 var globalModulesPath = String(exec('npm root -g')).replace(/\r?\n|\r/g, '')
 
+exports.resolve = function globalResolve (module) {
+  return path.resolve(globalModulesPath, module)
+}
+
 module.exports = function requireLocalNodeModule (module) {
   if (typeof module !== 'string' || !module.length) {
     throw new Error('Expecting module to be non-empty string')
   }
 
-  return require(path.resolve(globalModulesPath, module))
+  return require(exports.resolve(module))
 }


### PR DESCRIPTION
* add a global `require.resolve()` equivalent 
* cache global path (no need to `exec` on each call)
